### PR TITLE
fix: explicitly set pi-hole DNS server

### DIFF
--- a/pihole/.env.example
+++ b/pihole/.env.example
@@ -5,3 +5,4 @@
 
 DOCKER_VOLUME=${DOCKER_VOLUME_ROOT}/pihole # Path to the Pi-hole Docker volume
 HOST_IP_ADDRESS=192.168.1.225 # IP address of the host machine running Pi-hole
+PIHOLE_DNS=127.0.0.1 # DNS server to use for Pi-hole. More info at https://discourse.pi-hole.net/t/correct-resolv-conf-entry-in-pihole-5-11/35874/2

--- a/pihole/README.md
+++ b/pihole/README.md
@@ -25,3 +25,11 @@ This variable represents the path to the Docker volume that stores the configura
 #### HOST_IP_ADDRESS
 
 This variable represents the IP address of the host machine running the setup. It is necessary for proper configuration of the wildcard DNS and the services in general. Replace the placeholder value with the IP address of your host machine.
+
+#### PIHOLE_DNS
+
+The "PIHOLE_DNS" variable represents the DNS server used by Pi-hole. By default, it is set to "127.0.0.1", the loopback address, meaning the host device will use Pi-hole for DNS resolution. This configuration works well in most cases, but can cause issues if Pi-hole goes offline or experiences problems, as the host device may lose internet connectivity for troubleshooting or uploading debug logs.
+
+Since Pi-hole V5, the host device's name server remains unchanged during the installation, allowing you to choose an alternative DNS server for the host device if desired. For better resilience and troubleshooting, you may prefer to use a public DNS server, such as Cloudflare (1.1.1.1), OpenDNS, or Google DNS (8.8.8.8), as the "PIHOLE_DNS" value. This ensures that any issues with your local DNS server will not prevent your host device from accessing the internet.
+
+In summary, you can keep the default loopback address (127.0.0.1) if you want the host device to use Pi-hole for DNS resolution, or you can choose a public DNS server for increased reliability and easier troubleshooting.

--- a/pihole/docker-compose.sh
+++ b/pihole/docker-compose.sh
@@ -9,7 +9,7 @@ set -e
 command="${1:-'up'}"
 clean_stored_data="${2:-false}"
 overwrite_stored_data="${3:-false}"
-sub_directories="${4:-dnsmasq.d}"
+sub_directories="${4:-dnsmasq.d,etc}"
 owner="${5:-$SUDO_USER}"
 group="${6:-$SUDO_USER}"
 

--- a/pihole/docker-compose.yml
+++ b/pihole/docker-compose.yml
@@ -35,3 +35,4 @@ services:
     volumes:
       - ${DOCKER_VOLUME}/pihole:/etc/pihole:rw
       - ${DOCKER_VOLUME}/dnsmasq.d:/etc/dnsmasq.d:rw
+      - ${DOCKER_VOLUME}/etc/resolv.conf:/etc/resolv.conf:rw


### PR DESCRIPTION
## Description

This PR introduces a new environment variable, PIHOLE_DNS. This variable allows users to configure the DNS server used by Pi-hole, providing them with the flexibility to choose between using the loopback address (127.0.0.1) or a public DNS server like Cloudflare, OpenDNS, or Google DNS.

## Related Issue(s)

Please link to any related issues that this pull request addresses or resolves.

## Changes Made

Please provide a detailed description of the changes made in this pull request.

1. Add PIHOLE_DNS variable to the .env.example file with a default value of "127.0.0.1" (loopback address).
2. Update the README.md file to include a new section explaining the PIHOLE_DNS variable and its implications.
3. Create a `resolv.conf` to use in the container. 

## Screenshots

Please include any relevant screenshots of the changes, if applicable.

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
