### PR TITLE
feat: add `mullvad-browser` to the collection

### DIFF
--- a/mullvad-browser/.env.example
+++ b/mullvad-browser/.env.example
@@ -1,0 +1,6 @@
+# This is the .env.example file for the Docker Compose project.
+# It contains environment variables used to configure various services and
+# settings for the project. Rename this file to .env and replace the placeholder
+# values with your actual values.
+
+DOCKER_VOLUME=${DOCKER_VOLUME_ROOT}/mullvad-browser # The path where the volume is stored. "${DOCKER_VOLUME_ROOT}" should be set in "global.env".

--- a/mullvad-browser/README.md
+++ b/mullvad-browser/README.md
@@ -1,0 +1,15 @@
+# Mullvad Browser
+
+Mullvad Browser is a pre-configured web browser that uses the Mullvad VPN to ensure your online privacy and security. Mullvad VPN is a privacy-focused virtual private network (VPN) service that encrypts your internet connection, hides your IP address, and prevents online tracking. By using the Mullvad Browser, you can browse the internet with peace of mind, knowing that your online activities are secure and private.
+
+## Setup
+
+This section provides instructions on how to set up the Mullvad Browser container. For detailed information and additional options, please visit the official LinuxServer.io documentation: https://docs.linuxserver.io/images/docker-mullvad-browser
+
+### .env.example
+
+The `.env.example` file is a template containing placeholder values that you need to fill in. After replacing the placeholders with your actual values, rename the file to `.env`. This file is essential for configuring the environment variables required by the Mullvad Browser container.
+
+#### DOCKER_VOLUME
+
+This variable represents the path to the Docker volume that stores the configuration files and dependencies for the project. Replace the placeholder value with the appropriate path on your system.

--- a/mullvad-browser/docker-compose.sh
+++ b/mullvad-browser/docker-compose.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# This script is designed to deploy, stop, and remove Docker containers, networks, and volumes defined in the specified docker-compose.yml file.
+# It handles the deployment and management of a Docker environment, setting up the necessary directory, copying configuration files, and running
+# the appropriate Docker commands based on the provided arguments ('up' or 'down').
+# For more information, see ../utils/main.sh and ../README.md.
+
+command="${1:-'up'}"
+clean_stored_data="${2:-false}"
+overwrite_stored_data="${3:-false}"
+sub_directories="${4:-wireguard}"
+owner="${5:-$SUDO_USER}"
+group="${6:-$SUDO_USER}"
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source "$script_dir"/../utils/main.sh # Import script to execute the main function.
+main "$command" "$clean_stored_data" "$overwrite_stored_data" "$sub_directories" "$owner" "$group"
+
+# Ensure that the wg0.conf is not world accessible.
+chmod 600 "$DOCKER_VOLUME"/wireguard/wg0.conf

--- a/mullvad-browser/docker-compose.yml
+++ b/mullvad-browser/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+version: '3'
+
+networks:
+  proxy:
+    external: true
+
+services:
+  mullvad-browser:
+    cap_add:
+      - NET_ADMIN
+    container_name: mullvad-browser
+    environment:
+      - LOCAL_NET=192.168.0.0/16
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TIMEZONE}
+    image: lscr.io/linuxserver/mullvad-browser:latest
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.mullvad-secure.entrypoints=websecure
+      - traefik.http.routers.mullvad-secure.rule=Host(`mullvad.${DOMAIN}`)
+      - traefik.http.routers.mullvad-secure.service=mullvad
+      - traefik.http.routers.mullvad-secure.tls=true
+      - traefik.http.routers.mullvad-secure.tls.certresolver=cloudflare
+      - traefik.http.services.mullvad.loadbalancer.server.port=3000
+    networks:
+      - proxy
+    restart: unless-stopped
+    security_opt:
+      - seccomp:unconfined
+    shm_size: 1gb
+    sysctls:
+      net.ipv4.conf.all.src_valid_mark: 1
+      net.ipv6.conf.all.disable_ipv6: 0
+    volumes:
+      - ${DOCKER_VOLUME}/:/config:rw
+      - ${DOCKER_VOLUME}/wireguard/wg0.conf:/config/wg0.conf:rw

--- a/mullvad-browser/wireguard/wg0.conf.example
+++ b/mullvad-browser/wireguard/wg0.conf.example
@@ -1,0 +1,14 @@
+# This is a sample WireGuard configuration file
+# You should download the configuration file provided by your VPN provider.
+# For example, Mullvad VPN users can obtain the file at: https://mullvad.net/en/account/#/wireguard-config/
+# Make sure to select IPv4 as the server connection protocol.
+
+[Interface]
+PrivateKey = SAMPLE_PRIVATE_KEY # Your device's private key
+Address = 10.0.0.2/32,fc00:abcd:abcd:ab01::2/128 # IPv4 and IPv6 addresses assigned to your device
+DNS = 10.0.0.1 # DNS server to use for this connection
+
+[Peer]
+PublicKey = SAMPLE_PUBLIC_KEY # Public key of the remote peer (server or client)
+AllowedIPs = 0.0.0.0/0,::0/0 # IP range to route through the WireGuard tunnel (0.0.0.0/0 and ::0/0 for all IPv4 and IPv6 traffic)
+Endpoint = 192.168.1.1:51820 # Remote peer's IP address and listening port


### PR DESCRIPTION
## Description

This pull request adds a Docker Compose configuration for the Mullvad Browser, which is a pre-configured web browser that uses the Mullvad VPN for enhanced online privacy and security. It also includes an example environment file, a Docker Compose script, and a WireGuard configuration example.

## Related Issue(s)

N/A

## Changes Made

The following changes have been made in this pull request:

1. Added a `.env.example` file with placeholder values for the environment variables required by the Mullvad Browser container.
2. Added a `docker-compose.sh` script to deploy, stop, and remove Docker containers, networks, and volumes defined in the `docker-compose.yml` file.
3. Created a `docker-compose.yml` file that sets up the Mullvad Browser container with the necessary configuration.
4. Provided a `wireguard.conf.example` file as a sample WireGuard configuration file.
5. Updated the `README.md` with setup instructions for the Mullvad Browser container.

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.