### PR TITLE
feat: add `certresolver` to all services

### DIFF
--- a/pihole/docker-compose.yml
+++ b/pihole/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - traefik.http.routers.pihole-secure.rule=Host(`pihole.${DOMAIN}`)
       - traefik.http.routers.pihole-secure.service=pihole
       - traefik.http.routers.pihole-secure.tls=true
+      - traefik.http.routers.pihole-secure.tls.certresolver=cloudflare
       - traefik.http.services.pihole.loadbalancer.server.port=80
     networks:
       - proxy

--- a/plex/docker-compose.yml
+++ b/plex/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - traefik.http.routers.plex-secure.rule=Host(`plex.${DOMAIN}`)
       - traefik.http.routers.plex-secure.service=plex
       - traefik.http.routers.plex-secure.tls=true
+      - traefik.http.routers.plex-secure.tls.certresolver=cloudflare
       - traefik.http.services.plex.loadbalancer.server.port=32400
     network_mode: host
     restart: unless-stopped

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - traefik.http.routers.portainer-secure.rule=Host(`portainer.${DOMAIN}`)
       - traefik.http.routers.portainer-secure.service=portainer
       - traefik.http.routers.portainer-secure.tls=true
+      - traefik.http.routers.portainer-secure.tls.certresolver=cloudflare
       - traefik.http.services.portainer.loadbalancer.server.port=9000
     networks:
       - proxy

--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - traefik.http.routers.qbittorrent-secure.rule=Host(`qbittorrent.${DOMAIN}`)
       - traefik.http.routers.qbittorrent-secure.service=qbittorrent
       - traefik.http.routers.qbittorrent-secure.tls=true
+      - traefik.http.routers.qbittorrent-secure.tls.certresolver=cloudflare
       - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
     network_mode: service:wireguard
     restart: unless-stopped

--- a/servarr/docker-compose.yml
+++ b/servarr/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - traefik.http.routers.prowlarr-secure.rule=Host(`prowlarr.${DOMAIN}`)
       - traefik.http.routers.prowlarr-secure.service=prowlarr
       - traefik.http.routers.prowlarr-secure.tls=true
+      - traefik.http.routers.prowlarr-secure.tls.certresolver=cloudflare
       - traefik.http.services.prowlarr.loadbalancer.server.port=9696
     networks:
       - proxy
@@ -39,6 +40,7 @@ services:
       - traefik.http.routers.radarr-secure.rule=Host(`radarr.${DOMAIN}`)
       - traefik.http.routers.radarr-secure.service=radarr
       - traefik.http.routers.radarr-secure.tls=true
+      - traefik.http.routers.radarr-secure.tls.certresolver=cloudflare
       - traefik.http.services.radarr.loadbalancer.server.port=7878
     networks:
       - proxy
@@ -60,6 +62,7 @@ services:
       - traefik.http.routers.sonarr-secure.rule=Host(`sonarr.${DOMAIN}`)
       - traefik.http.routers.sonarr-secure.service=sonarr
       - traefik.http.routers.sonarr-secure.tls=true
+      - traefik.http.routers.sonarr-secure.tls.certresolver=cloudflare
       - traefik.http.services.sonarr.loadbalancer.server.port=8989
     networks:
       - proxy

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - traefik.http.routers.whoami-secure.entrypoints=websecure
       - traefik.http.routers.whoami-secure.rule=Host(`whoami.${DOMAIN}`)
       - traefik.http.routers.whoami-secure.tls=true
+      - traefik.http.routers.whoami-secure.tls.certresolver=cloudflare
       - traefik.http.routers.whoami-secure.service=whoami
       - traefik.http.services.whoami.loadbalancer.server.port=41234
     networks:


### PR DESCRIPTION
## Description

The changes in the PR explicitly define the certificate resolver for all services.

## Related Issue(s)

Please link to any related issues that this pull request addresses or resolves.

## Changes Made

Please provide a detailed description of the changes made in this pull request.

1. add `traefik.http.routers.<<service name>>-secure.tls.certresolver=cloudflare` to all services.

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
