### PR TITLE
chore: replace `latest` with actual tag for Renovate to act on

### DIFF
--- a/mullvad-browser/docker-compose.yml
+++ b/mullvad-browser/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/mullvad-browser:latest
+    image: lscr.io/linuxserver/mullvad-browser:12.0.4
     labels:
       - traefik.enable=true
       - traefik.http.routers.mullvad-secure.entrypoints=websecure

--- a/plex/docker-compose.yml
+++ b/plex/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - PUID=${PUID}
       - TZ=${TIMEZONE}
       - VERSION=latest
-    image: lscr.io/linuxserver/plex:latest
+    image: lscr.io/linuxserver/plex:1.32.0
     labels:
       - traefik.enable=true
       - traefik.http.routers.plex-secure.entrypoints=websecure

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 services:
   portainer:
     container_name: portainer
-    image: portainer/portainer-ce:latest
+    image: portainer/portainer-ce:2.18.1
     labels:
       - traefik.enable=true
       - traefik.http.routers.portainer-secure.entrypoints=websecure

--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - PUID=${PUID}
       - TZ=${TIMEZONE}
       - WEBUI_PORT=8080
-    image: linuxserver/qbittorrent:latest
+    image: linuxserver/qbittorrent:4.5.2
     labels:
       - traefik.enable=true
       - traefik.http.routers.qbittorrent-secure.entrypoints=websecure
@@ -39,7 +39,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: linuxserver/wireguard:latest
+    image: linuxserver/wireguard:1.0.20210914
     networks:
       - proxy
     ports:

--- a/servarr/docker-compose.yml
+++ b/servarr/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/prowlarr:latest
+    image: lscr.io/linuxserver/prowlarr:1.3.2
     labels:
       - traefik.enable=true
       - traefik.http.routers.prowlarr-secure.entrypoints=websecure
@@ -33,7 +33,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/radarr:latest
+    image: lscr.io/linuxserver/radarr:4.4.4
     labels:
       - traefik.enable=true
       - traefik.http.routers.radarr-secure.entrypoints=websecure
@@ -55,7 +55,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/sonarr:latest
+    image: lscr.io/linuxserver/sonarr:3.0.10
     labels:
       - traefik.enable=true
       - traefik.http.routers.sonarr-secure.entrypoints=websecure


### PR DESCRIPTION
## Description

Replace all `latest` tags with a version tag. This will make it possible for Renovate to read the version and update it.

## Related Issue(s)

N/A

## Changes Made

Please provide a detailed description of the changes made in this pull request.

1. Replace `latest` with version, e.g. 2.3.4

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
