### PR TITLE
chore: ignore Prowlarr versions `>=1.8`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "gitAuthor": "Eric Ribeiro <ericribeiro@outlook.com.br>"
+  "gitAuthor": "Eric Ribeiro <ericribeiro@outlook.com.br>",
+  "packageRules": [
+    {
+      "matchPackageNames": ["prowlarr"],
+      "allowedVersions": "<1.8"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

This change makes Renovate ignore tags larger or equal to v1.8 for the Prowlarr image.

## Related Issue(s)

See https://github.com/linuxserver/docker-prowlarr/issues/42 for more information.

## Changes Made

Please provide a detailed description of the changes made in this pull request.

1. Add `packageRules` to the Renovate configuration file.

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
