### PR TITLE
chore: add `lscr.io` prefix to images

### DIFF
--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - PUID=${PUID}
       - TZ=${TIMEZONE}
       - WEBUI_PORT=8080
-    image: linuxserver/qbittorrent:4.5.2
+    image: lscr.io/linuxserver/qbittorrent:4.5.2
     labels:
       - traefik.enable=true
       - traefik.http.routers.qbittorrent-secure.entrypoints=websecure
@@ -39,7 +39,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: linuxserver/wireguard:1.0.20210914
+    image: lscr.io/linuxserver/wireguard:1.0.20210914
     networks:
       - proxy
     ports:


### PR DESCRIPTION
## Description

Add the LinuxServer prefix to images.

## Related Issue(s)

N/A

## Changes Made

1. Add `lscr.io` to qbittorrent and wireguard.

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
