### PR TITLE
feat: replace Portainer `ce` with `ee`

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 services:
   portainer:
     container_name: portainer
-    image: portainer/portainer-ce:2.18.1
+    image: portainer/portainer-ee:2.18.1
     labels:
       - traefik.enable=true
       - traefik.http.routers.portainer-secure.entrypoints=websecure


### PR DESCRIPTION
## Description

This pull request updates the Docker Compose file to change the Portainer image from the Community Edition (CE) to the Enterprise Edition (EE).

## Related Issue(s)

_None_

## Changes Made

The following change has been made in the Docker Compose file:

1. The image has been updated from `image: portainer/portainer-ce:2.18.1` to `image: portainer/portainer-ee:2.18.1`.

The reason for this change is that Portainer now offers their Enterprise Edition for free for users with up to 5 nodes. By upgrading to the Enterprise Edition, users can take advantage of the additional features and capabilities provided by Portainer EE without incurring any additional costs.

## Screenshots

_Not applicable_

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.