### PR TITLE
feat: add `calibre` to the collection

### DIFF
--- a/calibre/.env.example
+++ b/calibre/.env.example
@@ -1,0 +1,9 @@
+# This is the .env.example file for the Docker Compose project.
+# It contains environment variables used to configure various services and
+# settings for the project. Rename this file to .env and replace the placeholder
+# values with your actual values.
+
+CALIBRE_PASSWORD=password123 # The password used to access Calibre.
+CALIBRE_USER=user # The username used to access Calibre.
+DOCKER_DATA_VOLUME=your_data_volume # The path where your books are stored in the host system. You will access it from Calibre to add books in the library.
+DOCKER_VOLUME=${DOCKER_VOLUME_ROOT}/calibre # The path where the volume is stored. "${DOCKER_VOLUME_ROOT}" should be set in "global.env".

--- a/calibre/README.md
+++ b/calibre/README.md
@@ -1,0 +1,27 @@
+# Calibre
+
+Calibre is an open-source and powerful e-book management tool that allows you to organize, convert, and sync your e-book collection across various devices. It supports a wide range of e-book formats and devices, making it a versatile solution for avid readers and e-book enthusiasts. Calibre is useful for managing your personal e-book library, converting e-books to different formats, and syncing them with your favorite e-reader devices.
+
+## Setup
+
+This section provides instructions on how to set up the Calibre container. For detailed information and additional options, please visit the official LinuxServer.io documentation: https://docs.linuxserver.io/images/docker-calibre
+
+### .env.example
+
+The `.env.example` file is a template containing placeholder values that you need to fill in. After replacing the placeholders with your actual values, rename the file to `.env`. This file is essential for configuring the environment variables required by the container.
+
+#### CALIBRE_PASSWORD
+
+This variable sets the HTTP Basic authentication password for the Calibre container. The default value is `abc`. If this variable is not set, there will be no authentication required to access the Calibre web interface.
+
+#### CALIBRE_USER
+
+This variable sets the HTTP Basic authentication username for the Calibre container. The default value is `abc`.
+
+#### DOCKER_VOLUME
+
+This variable represents the path to the Docker volume that stores the configuration files and dependencies for the project. Replace the placeholder value with the appropriate path on your system.
+
+#### DOCKER_DATA_VOLUME
+
+This variable determines where the host machine's books are stored. Replace the placeholder value with the path to your e-book collection on your host system. This path will be mapped to `/books` in the container so that books can be added to Calibre easily.

--- a/calibre/docker-compose.sh
+++ b/calibre/docker-compose.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# This script is designed to deploy, stop, and remove Docker containers, networks, and volumes defined in the specified docker-compose.yml file.
+# It handles the deployment and management of a Docker environment, setting up the necessary directory, copying configuration files, and running
+# the appropriate Docker commands based on the provided arguments ('up' or 'down').
+# For more information, see ../utils/main.sh and ../README.md.
+
+command="${1:-'up'}"
+clean_stored_data="${2:-false}"
+overwrite_stored_data="${3:-false}"
+sub_directories="${4:-}"
+owner="${5:-$SUDO_USER}"
+group="${6:-$SUDO_USER}"
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+source "$script_dir"/../utils/main.sh # Import script to execute the main function.
+main "$command" "$clean_stored_data" "$overwrite_stored_data" "$sub_directories" "$owner" "$group"

--- a/calibre/docker-compose.yml
+++ b/calibre/docker-compose.yml
@@ -1,0 +1,33 @@
+---
+version: '3'
+
+networks:
+  proxy:
+    external: true
+
+services:
+  calibre:
+    container_name: calibre
+    environment:
+      - CUSTOM_USER=${CALIBRE_USER}
+      - PASSWORD=${CALIBRE_PASSWORD}
+      - PGID=${PGID}
+      - PUID=${PUID}
+      - TZ=${TIMEZONE}
+    image: lscr.io/linuxserver/calibre:6.17.0
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.calibre-secure.entrypoints=websecure
+      - traefik.http.routers.calibre-secure.rule=Host(`calibre.${DOMAIN}`)
+      - traefik.http.routers.calibre-secure.service=calibre
+      - traefik.http.routers.calibre-secure.tls=true
+      - traefik.http.routers.calibre-secure.tls.certresolver=cloudflare
+      - traefik.http.services.calibre.loadbalancer.server.port=8080
+    networks:
+      - proxy
+    restart: unless-stopped
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ${DOCKER_VOLUME}/:/config:rw
+      - ${DOCKER_DATA_VOLUME}/:/books:rw

--- a/qbittorrent/qBittorrent/categories.json
+++ b/qbittorrent/qBittorrent/categories.json
@@ -2,6 +2,9 @@
     "anime": {
         "save_path": "anime"
     },
+    "books": {
+        "save_path": "books"
+    },
     "movies": {
         "save_path": "movies"
     },


### PR DESCRIPTION
## Description

This pull request adds a Docker Compose configuration for deploying Calibre as a container, making it easier for users to set up and manage their e-book library.

## Related Issue(s)

N/A

## Changes Made

The changes made in this pull request include:

1. Adding a `.env.example` file for users to configure environment variables required by the Calibre container.
2. Updating the `README.md` file with instructions on how to set up the Calibre container.
3. Creating a `docker-compose.sh` script for deploying, stopping, and removing the Calibre container and associated resources.
4. Adding a `docker-compose.yml` file containing the necessary configuration for deploying the Calibre container, including Traefik labels for reverse proxy support.

## Screenshots

N/A

## Checklist

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.