### PR TITLE
feat: add script to easily `up` or `down` container

### DIFF
--- a/docker-compose-all.sh
+++ b/docker-compose-all.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Check if the script is running as root
+if [[ $EUID -ne 0 ]]; then
+   printf '%s\n' "This script must be run as root"
+   exit 1
+fi
+
+set -e
+
+# Check if the first argument is "up" or "down", default to "up" if not provided or invalid
+[[ "$1" == "down" ]] && action="down" || action="up"
+
+# Excluded directories
+exclude=(
+  ".github"
+  "utils"
+  "calibre"
+  "mullvad-browser"
+  "pihole"
+  "renovate"
+  "whoogle"
+)
+
+# In case of 'down' action, 'traefik' should be handled last
+[[ $action == "down" ]] && exclude+=("traefik")
+
+for dir in ./*; do
+    if [[ -d "$dir" ]]; then
+        # Remove './' from directory name
+        dir_name=$(basename "$dir")
+
+        if ! [[ ${exclude[*]} =~ $dir_name ]]; then
+            sudo "$dir/docker-compose.sh" $action
+        fi
+    fi
+done
+
+# If the action is 'down', we need to run the action on 'traefik' last
+if [[ $action == "down" && -d "./traefik" ]]; then
+    sudo "./traefik/docker-compose.sh" $action
+fi

--- a/sabnzbd/docker-compose.yml
+++ b/sabnzbd/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/sabnzbd:4.0.2-ls114
+    image: lscr.io/linuxserver/sabnzbd:4.0.3
     labels:
       - traefik.enable=true
       - traefik.http.routers.sabnzbd-secure.entrypoints=websecure

--- a/servarr/docker-compose.yml
+++ b/servarr/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - PGID=${PGID}
       - PUID=${PUID}
       - TZ=${TIMEZONE}
-    image: lscr.io/linuxserver/prowlarr:1.6.3
+    image: lscr.io/linuxserver/prowlarr:1.7.4
     labels:
       - traefik.enable=true
       - traefik.http.routers.prowlarr-secure.entrypoints=websecure

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}
     extra_hosts:
       - host.docker.internal:172.17.0.1 # Map the hostname 'host.docker.internal' to the IP address '172.17.0.1' to allow the Traefik container to access services running on the host machine or other containers in the same Docker network using the 'host.docker.internal' hostname.
-    image: traefik:v2.10
+    image: traefik:v2.10.4
     labels:
       - traefik.enable=true
       - traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https


### PR DESCRIPTION
## Description

Add a script to run `docker compose {up, down}` for every directory not excluded.

## Related Issue(s)

N/A

## Changes Made

N/A

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
