### PR TITLE
fix: qbittorrent seed volume

### DIFF
--- a/qbittorrent/.env.example
+++ b/qbittorrent/.env.example
@@ -5,6 +5,7 @@
 
 DOCKER_VOLUME=${DOCKER_VOLUME_ROOT}/qbittorrent # Absolute path for qBittorrent container's root directory
 DOCKER_DATA_VOLUME=your_data_volume # Name of the Docker data volume for qBittorrent
+DOCKER_SEED_VOLUME=your_seed_volume # Name of the Docker data volume for qBittorrent seeding
 QBITTORRENT_INCOMING_PORT=your_incoming_port # Incoming port number for qBittorrent to listen on
 WEBUI_AUTH_SUBNET_WHITELIST=192.168.240.0/24 # Whitelisted IP subnet for qBittorrent web UI authentication
 

--- a/qbittorrent/README.md
+++ b/qbittorrent/README.md
@@ -75,6 +75,10 @@ This variable represents the path to the Docker volume that stores the configura
 
 This variable determines where the downloads will be stored. Before deciding on its value, read TRaSH's [Docker setup guide](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) and Servarr's [Docker guide](https://wiki.servarr.com/docker-guide).
 
+#### DOCKER_SEED_VOLUME
+
+This variable dictates where torrents with the `seed` category will be stored. This is its own variable to allow for different storage locations for seeding torrents.
+
 ##### External SSD
 
 I am testing this setup with an external SSD connected to a Raspberry Pi 4 and mounted in the OS. The following line in `/etc/fstab` mounts the SSD: `UUID=device_uuid /mount_directory auto nosuid,nodev,nofail,uid=1000,gid=1000 0 0`. This line requires the device UUID and user/group IDs, which are explained in more detail below.

--- a/qbittorrent/docker-compose.yml
+++ b/qbittorrent/docker-compose.yml
@@ -27,8 +27,9 @@ services:
     network_mode: service:wireguard
     restart: unless-stopped
     volumes:
-      - ${DOCKER_VOLUME}/:/config:rw
       - ${DOCKER_DATA_VOLUME}:/data/torrents:rw
+      - ${DOCKER_SEED_VOLUME}:/data/seed:rw
+      - ${DOCKER_VOLUME}/:/config:rw
 
   wireguard:
     cap_add:

--- a/qbittorrent/qBittorrent/categories.json
+++ b/qbittorrent/qBittorrent/categories.json
@@ -1,14 +1,17 @@
 {
     "anime": {
-        "save_path": "anime"
+        "save_path": "torrents/anime"
     },
     "books": {
-        "save_path": "books"
+        "save_path": "torrents/books"
     },
     "movies": {
-        "save_path": "movies"
+        "save_path": "torrents/movies"
+    },
+    "seed": {
+        "save_path": "seed"
     },
     "tv": {
-        "save_path": "tv"
+        "save_path": "torrents/tv"
     }
 }

--- a/qbittorrent/qBittorrent/qBittorrent.conf
+++ b/qbittorrent/qBittorrent/qBittorrent.conf
@@ -8,7 +8,7 @@ enabled=false
 program=
 
 [BitTorrent]
-Session\DefaultSavePath=/data/torrents
+Session\DefaultSavePath=/data
 Session\DisableAutoTMMByDefault=false
 Session\DisableAutoTMMTriggers\CategorySavePathChanged=false
 Session\DisableAutoTMMTriggers\DefaultSavePathChanged=false


### PR DESCRIPTION
## Description

Fix the issue with seed volume in qBittorrent.

## Related Issue(s)

N/A

## Changes Made

1. Update `.env.example` and the `README.md` to include the new variable.
2. Update the `docker-compose.yml` to mount the seed volume.
3. Update the `categories.json` and the `qbittorrent.conf` to accommodate the seed path.

## Screenshots

N/A

## Checklist

Please ensure that the following items have been completed before submitting this pull request:

- [x] The code compiles and runs without errors or warnings.
- [x] The code is properly tested.
- [x] All changes are documented.
- [x] Code style and formatting are consistent with the existing codebase.
- [x] All commits are properly formatted and messages are clear and descriptive.
